### PR TITLE
Migrate Airflow to v2.11 with local docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here are some of the most interesting features used:
 
 
 To run the Airflow ETL copy contents of [airflow](airflow) folder to `$AIRFLOW_HOME` or use the docker compose setup in `docker/airflow`.
-The folder contains `.py` with DAG definition and plugins folder with one custom operator. The compose file initializes the database using an `airflow-init` service before starting Airflow.
+The folder contains `.py` with DAG definition and plugins folder with one custom operator. The compose file initializes the database using an `airflow-init` service and installs the needed providers before starting Airflow.
 
 ![](docs/dag_complete.png)
 
@@ -247,7 +247,8 @@ $ docker run -p 8888:8888 -v $(pwd):/home/jovyan airbnb-etl
 ### 3. Airflow
 The project now uses Airflow 2.11. A docker compose file is provided to run the
 DAG locally. The metadata database is initialized automatically using the
-`airflow-init` service.
+`airflow-init` service and installs the required Amazon and Postgres provider
+packages.
 
 ```
 $ docker compose -f docker/airflow/docker-compose.yml up

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ $ docker run -p 8888:8888 -v $(pwd):/home/jovyan airbnb-etl
 
 ### 3. Airflow
 The project now uses Airflow 2.11. A docker compose file is provided to run the
-DAG locally. The metadata database is initialized automatically using the
-`airflow-init` service and installs the required Amazon and Postgres provider
-packages.
+DAG locally. The services install the dependencies listed in
+`docker/airflow/requirements.txt` and the metadata database is initialised
+automatically using the `airflow-init` service.
 
 ```
 $ docker compose -f docker/airflow/docker-compose.yml up

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Here are some of the most interesting features used:
 - Postgres operator for connection to Redshift
 
 
-To run the Airflow ETL copy contents of [airflow](airflow) folder to `$AIRFLOW_HOME` or start the docker compose setup from `docker/airflow`.
-The folder contains `.py` with DAG definition and plugins folder with one custom operator.
+To run the Airflow ETL copy contents of [airflow](airflow) folder to `$AIRFLOW_HOME` or use the docker compose setup in `docker/airflow`.
+The folder contains `.py` with DAG definition and plugins folder with one custom operator. The compose file initializes the database using an `airflow-init` service before starting Airflow.
 
 ![](docs/dag_complete.png)
 
@@ -246,7 +246,8 @@ $ docker run -p 8888:8888 -v $(pwd):/home/jovyan airbnb-etl
 
 ### 3. Airflow
 The project now uses Airflow 2.11. A docker compose file is provided to run the
-DAG locally.
+DAG locally. The metadata database is initialized automatically using the
+`airflow-init` service.
 
 ```
 $ docker compose -f docker/airflow/docker-compose.yml up

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Here are some of the most interesting features used:
 - Postgres operator for connection to Redshift
 
 
-To run the Airflow ETL copy contents of [airflow](airflow) folder to $AIRFLOW_HOME. The folder contains .py with DAG definition and plugins folder with one custom operator.
+To run the Airflow ETL copy contents of [airflow](airflow) folder to `$AIRFLOW_HOME` or start the docker compose setup from `docker/airflow`.
+The folder contains `.py` with DAG definition and plugins folder with one custom operator.
 
 ![](docs/dag_complete.png)
 
@@ -244,11 +245,15 @@ $ docker run -p 8888:8888 -v $(pwd):/home/jovyan airbnb-etl
 ```
 
 ### 3. Airflow
-Works with Python 3.7.10, Airflow 1.10.9 using LocalExecutor with Postgres 9.6.
+The project now uses Airflow 2.11. A docker compose file is provided to run the
+DAG locally.
+
 ```
-pip install apache-airflow[postgres,aws]==1.10.9
-pip install sqlalchemy==1.3.15
+$ docker compose -f docker/airflow/docker-compose.yml up
 ```
+
+The web UI will be available at http://localhost:8080 (credentials
+`admin`/`admin`).
 
 ## Exploring the data
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here are some of the most interesting features used:
 
 
 To run the Airflow ETL copy contents of [airflow](airflow) folder to `$AIRFLOW_HOME` or use the docker compose setup in `docker/airflow`.
-The folder contains `.py` with DAG definition and plugins folder with one custom operator. The compose file initializes the database using an `airflow-init` service and installs the needed providers before starting Airflow.
+The folder contains `.py` with DAG definition and plugins folder with one custom operator. The compose file initializes the database using an `airflow-init` service and installs the providers listed in `docker/airflow/requirements.txt` through a shared configuration for all Airflow containers.
 
 ![](docs/dag_complete.png)
 
@@ -246,9 +246,9 @@ $ docker run -p 8888:8888 -v $(pwd):/home/jovyan airbnb-etl
 
 ### 3. Airflow
 The project now uses Airflow 2.11. A docker compose file is provided to run the
-DAG locally. The services install the dependencies listed in
-`docker/airflow/requirements.txt` and the metadata database is initialised
-automatically using the `airflow-init` service.
+DAG locally. Both the scheduler and init container reuse a common configuration
+that installs the dependencies listed in `docker/airflow/requirements.txt`. The
+metadata database is initialised automatically using the `airflow-init` service.
 
 ```
 $ docker compose -f docker/airflow/docker-compose.yml up

--- a/airflow/AIRFLOW_HOME/dags/airbnb-etl-airflow.py
+++ b/airflow/AIRFLOW_HOME/dags/airbnb-etl-airflow.py
@@ -3,7 +3,7 @@ from airflow import DAG
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.operators.postgres import PostgresOperator
-from airflow.providers.amazon.aws.operators.emr_add_steps import EmrAddStepsOperator
+from airflow.providers.amazon.aws.operators.emr import EmrAddStepsOperator
 from airflow.providers.amazon.aws.sensors.emr import EmrStepSensor
 from airflow.providers.amazon.aws.hooks.emr import EmrHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -170,8 +170,7 @@ preprocess_data_submit = EmrAddStepsOperator(
                 },
             }
     ],   
-    dag=dag,
-    provide_context = True
+    dag=dag
 )
 
 preprocess_data_wait = EmrStepSensor(
@@ -212,8 +211,7 @@ process_listings_hosts_submit = EmrAddStepsOperator(
                 },
             }
     ],   
-    dag=dag,
-    provide_context = True
+    dag=dag
 )
 
 process_listings_hosts_wait = EmrStepSensor(
@@ -249,8 +247,7 @@ process_reviews_submit = EmrAddStepsOperator(
                 },
             }
     ],   
-    dag=dag,
-    provide_context = True
+    dag=dag
 )
 
 process_reviews_wait = EmrStepSensor(
@@ -286,8 +283,7 @@ process_reviewers_submit = EmrAddStepsOperator(
                 },
             }
     ],   
-    dag=dag,
-    provide_context = True
+    dag=dag
 )
 
 process_reviewers_wait = EmrStepSensor(
@@ -323,8 +319,7 @@ process_weather_submit = EmrAddStepsOperator(
                 },
             }
     ],   
-    dag=dag,
-    provide_context = True
+    dag=dag
 )
 
 process_weather_wait = EmrStepSensor(

--- a/airflow/AIRFLOW_HOME/dags/airbnb-etl-airflow.py
+++ b/airflow/AIRFLOW_HOME/dags/airbnb-etl-airflow.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timedelta
 from airflow import DAG
-from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.python_operator import PythonOperator
-from airflow.operators.postgres_operator import PostgresOperator
-from airflow.contrib.operators.emr_add_steps_operator import EmrAddStepsOperator
-from airflow.contrib.sensors.emr_step_sensor import EmrStepSensor
-from airflow.contrib.hooks.emr_hook import EmrHook
-from airflow.hooks.S3_hook import S3Hook
-from airflow.hooks.postgres_hook import PostgresHook
+from airflow.operators.dummy import DummyOperator
+from airflow.operators.python import PythonOperator
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.amazon.aws.operators.emr_add_steps import EmrAddStepsOperator
+from airflow.providers.amazon.aws.sensors.emr import EmrStepSensor
+from airflow.providers.amazon.aws.hooks.emr import EmrHook
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 from operators.s3_to_redshift_operator import S3ToRedshiftTransfer_custom
 

--- a/airflow/AIRFLOW_HOME/plugins/operators/s3_to_redshift_operator.py
+++ b/airflow/AIRFLOW_HOME/plugins/operators/s3_to_redshift_operator.py
@@ -17,8 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.hooks.postgres_hook import PostgresHook
-from airflow.hooks.S3_hook import S3Hook
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/docker/airflow/docker-compose.yml
+++ b/docker/airflow/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
     command: >
       bash -c "airflow db migrate &&\
-      airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com --skip-if-exists"
+      airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com"
 
   airflow:
     image: apache/airflow:2.11.0

--- a/docker/airflow/docker-compose.yml
+++ b/docker/airflow/docker-compose.yml
@@ -1,3 +1,15 @@
+x-airflow-common: &airflow-common
+  image: apache/airflow:2.11.0
+  environment:
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+    AIRFLOW__CORE__EXECUTOR: LocalExecutor
+    AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+    _PIP_ADDITIONAL_REQUIREMENTS: -r /requirements.txt
+  volumes:
+    - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
+    - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
+    - ./requirements.txt:/requirements.txt
+
 services:
   postgres:
     image: postgres:15
@@ -11,39 +23,21 @@ services:
       retries: 5
 
   airflow-init:
-    image: apache/airflow:2.11.0
+    <<: *airflow-common
     depends_on:
       postgres:
         condition: service_healthy
-    environment:
-      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
-      AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
-      _PIP_ADDITIONAL_REQUIREMENTS: -r /requirements.txt
-    volumes:
-      - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
-      - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
-      - ./requirements.txt:/requirements.txt
     command: >
       bash -c "airflow db migrate &&\
       airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com"
 
   airflow:
-    image: apache/airflow:2.11.0
+    <<: *airflow-common
     depends_on:
       postgres:
         condition: service_healthy
       airflow-init:
         condition: service_completed_successfully
-    environment:
-      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
-      AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
-      _PIP_ADDITIONAL_REQUIREMENTS: -r /requirements.txt
-    volumes:
-      - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
-      - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
-      - ./requirements.txt:/requirements.txt
     ports:
       - "8080:8080"
     command: >

--- a/docker/airflow/docker-compose.yml
+++ b/docker/airflow/docker-compose.yml
@@ -19,12 +19,11 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
-      _PIP_ADDITIONAL_REQUIREMENTS: >-
-        apache-airflow-providers-amazon
-        apache-airflow-providers-postgres
+      _PIP_ADDITIONAL_REQUIREMENTS: -r /requirements.txt
     volumes:
       - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
       - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
+      - ./requirements.txt:/requirements.txt
     command: >
       bash -c "airflow db migrate &&\
       airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com"
@@ -40,12 +39,11 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
-      _PIP_ADDITIONAL_REQUIREMENTS: >-
-        apache-airflow-providers-amazon
-        apache-airflow-providers-postgres
+      _PIP_ADDITIONAL_REQUIREMENTS: -r /requirements.txt
     volumes:
       - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
       - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
+      - ./requirements.txt:/requirements.txt
     ports:
       - "8080:8080"
     command: >

--- a/docker/airflow/docker-compose.yml
+++ b/docker/airflow/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   postgres:
     image: postgres:15
@@ -11,7 +10,7 @@ services:
       interval: 5s
       retries: 5
 
-  airflow:
+  airflow-init:
     image: apache/airflow:2.11.0
     depends_on:
       postgres:
@@ -23,10 +22,26 @@ services:
     volumes:
       - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
       - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
+    command: >
+      bash -c "airflow db migrate &&\
+      airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com --skip-if-exists"
+
+  airflow:
+    image: apache/airflow:2.11.0
+    depends_on:
+      postgres:
+        condition: service_healthy
+      airflow-init:
+        condition: service_completed_successfully
+    environment:
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+      AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+    volumes:
+      - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
+      - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
     ports:
       - "8080:8080"
     command: >
-      bash -c "airflow db upgrade &&\
-      airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com --skip-if-exists &&\
-      airflow scheduler & exec airflow webserver"
+      bash -c "airflow scheduler & exec airflow webserver"
 

--- a/docker/airflow/docker-compose.yml
+++ b/docker/airflow/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U airflow"]
+      interval: 5s
+      retries: 5
+
+  airflow:
+    image: apache/airflow:2.11.0
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
+      AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+    volumes:
+      - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
+      - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
+    ports:
+      - "8080:8080"
+    command: >
+      bash -c "airflow db upgrade &&\
+      airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com --skip-if-exists &&\
+      airflow scheduler & exec airflow webserver"
+

--- a/docker/airflow/docker-compose.yml
+++ b/docker/airflow/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+      _PIP_ADDITIONAL_REQUIREMENTS: >-
+        apache-airflow-providers-amazon
+        apache-airflow-providers-postgres
     volumes:
       - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
       - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins
@@ -37,6 +40,9 @@ services:
       AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+      _PIP_ADDITIONAL_REQUIREMENTS: >-
+        apache-airflow-providers-amazon
+        apache-airflow-providers-postgres
     volumes:
       - ../../airflow/AIRFLOW_HOME/dags:/opt/airflow/dags
       - ../../airflow/AIRFLOW_HOME/plugins:/opt/airflow/plugins

--- a/docker/airflow/requirements.txt
+++ b/docker/airflow/requirements.txt
@@ -1,0 +1,3 @@
+apache-airflow==2.11.0
+apache-airflow-providers-amazon==9.8.0
+apache-airflow-providers-postgres==5.14.0


### PR DESCRIPTION
## Summary
- update Airflow DAG and plugin imports for Airflow 2.11
- document new Airflow setup
- add docker compose file to run Airflow locally

## Testing
- `python -m py_compile airflow/AIRFLOW_HOME/dags/airbnb-etl-airflow.py`
- `python -m py_compile airflow/AIRFLOW_HOME/plugins/operators/s3_to_redshift_operator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684591f455348324964bd07411ab8307