### PR TITLE
Improve path handling across apps

### DIFF
--- a/apps/preprocess_data.py
+++ b/apps/preprocess_data.py
@@ -4,9 +4,10 @@ import sys
 
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame, SparkSession
-from apps.utils import join_path, model_exists
 
-BUCKET_NAME = "airbnbprj-us"
+from apps.utils import DEFAULT_BUCKET_NAME, build_paths, model_exists
+
+BUCKET_NAME = DEFAULT_BUCKET_NAME
 
 
 def clean_global_listings(df: DataFrame) -> DataFrame:
@@ -58,63 +59,11 @@ def main(base_uri: str):
     ## Paths
     TEST = False
 
-    # S3
-    path_global_listings = "airbnb-listings.csv"
-    path_city_listings = f"cities/*/{scrape_year_month}/listings.csv"
-    path_city_reviews = f"cities/*/{scrape_year_month}/reviews.csv"
+    paths = build_paths(base_uri, scrape_year_month, TEST)
 
-    path_city_temperature = "weather/ECA_blend_tg/*.txt"
-    path_city_rain = "weather/ECA_blend_rr/*.txt"
-
-    raw_data_folder = "raw"
-    # input_parquet_folder = "input_parquets_notebook"
-    # dim_model_folder = "dim_model_notebook"
-    # dim_model_folder_new = "dim_model_notebook_temp"
-    input_parquet_folder = "input_parquets_airflow"
-    dim_model_folder = "dim_model_airflow"
-    dim_model_folder_new = "dim_model_airflow_temp"
-
-    if TEST:
-        input_parquet_folder += "_test"
-        dim_model_folder += "_test"
-        dim_model_folder_new += "_test"
-
-    raw_global_listings_path = join_path(base_uri, raw_data_folder, path_global_listings)
-    raw_city_listings_path = join_path(base_uri, raw_data_folder, path_city_listings)
-    raw_city_reviews_path = join_path(base_uri, raw_data_folder, path_city_reviews)
-    raw_city_temperature_path = join_path(base_uri, raw_data_folder, path_city_temperature)
-    raw_city_rain_data_path = join_path(base_uri, raw_data_folder, path_city_rain)
-
-    path_out_global_listings = join_path(base_uri, input_parquet_folder, "global_listings.parquet")
-    path_out_city_listings_data = join_path(
-        base_uri, input_parquet_folder, f"city_listings/{scrape_year_month}/city_listings.parquet"
-    )
-    path_out_city_reviews_data = join_path(
-        base_uri, input_parquet_folder, f"city_reviews/{scrape_year_month}/city_reviews.parquet"
-    )
-    path_out_city_temperature_data = join_path(base_uri, input_parquet_folder, "city_temperature.parquet")
-    path_out_city_rain_data = join_path(base_uri, input_parquet_folder, "city_rain.parquet")
-    path_out_weather_stations = join_path(base_uri, input_parquet_folder, "weather_stations.parquet")
-
-    dim_model_listings = join_path(base_uri, dim_model_folder, "listings.csv")
-    dim_model_hosts = join_path(base_uri, dim_model_folder, "hosts.csv")
-    dim_model_reviews = join_path(base_uri, dim_model_folder, "reviews.csv")
-    dim_model_reviewers = join_path(base_uri, dim_model_folder, "reviewers.csv")
-    dim_model_weather = join_path(base_uri, dim_model_folder, "weather.csv")
-
-    dim_model_listings_new = join_path(base_uri, dim_model_folder_new, "listings.csv")
-    dim_model_hosts_new = join_path(base_uri, dim_model_folder_new, "hosts.csv")
-    dim_model_reviews_new = join_path(base_uri, dim_model_folder_new, "reviews.csv")
-    dim_model_reviewers_new = join_path(base_uri, dim_model_folder_new, "reviewers.csv")
-    dim_model_weather_new = join_path(base_uri, dim_model_folder_new, "weather.csv")
-
-    dim_model_reviews_step1 = join_path(base_uri, dim_model_folder_new, "reviews_step1.csv")
-    dim_model_reviews_step2 = join_path(base_uri, dim_model_folder_new, "reviews_step2.csv")
-    ##
-
-    if not model_exists(path_out_global_listings):
+    if not model_exists(paths.path_out_global_listings):
         df_global_listings = spark.read.csv(
-            raw_global_listings_path,
+            paths.raw_global_listings,
             header="True",
             inferSchema="True",
             multiLine="True",
@@ -126,14 +75,14 @@ def main(base_uri: str):
 
         if TEST:
             df_global_listings.filter("city = 'Amsterdam'").write.partitionBy("scrape_year", "scrape_month").parquet(
-                path_out_global_listings
+                paths.path_out_global_listings
             )
         else:
-            df_global_listings.write.partitionBy("scrape_year", "scrape_month").parquet(path_out_global_listings)
+            df_global_listings.write.partitionBy("scrape_year", "scrape_month").parquet(paths.path_out_global_listings)
 
-    if not model_exists(path_out_city_listings_data):
+    if not model_exists(paths.path_out_city_listings_data):
         df_city_listings = spark.read.csv(
-            raw_city_listings_path,
+            paths.raw_city_listings,
             header="True",
             inferSchema="True",
             multiLine="True",
@@ -147,14 +96,14 @@ def main(base_uri: str):
 
         if TEST:
             df_city_listings.filter("city = 'Amsterdam'").write.partitionBy("scrape_year", "scrape_month").parquet(
-                path_out_city_listings_data
+                paths.path_out_city_listings_data
             )
         else:
-            df_city_listings.write.partitionBy("scrape_year", "scrape_month").parquet(path_out_city_listings_data)
+            df_city_listings.write.partitionBy("scrape_year", "scrape_month").parquet(paths.path_out_city_listings_data)
 
-    if not model_exists(path_out_city_reviews_data):
+    if not model_exists(paths.path_out_city_reviews_data):
         df_city_reviews = spark.read.csv(
-            raw_city_reviews_path,
+            paths.raw_city_reviews,
             header="True",
             inferSchema="True",
             multiLine="True",
@@ -168,14 +117,14 @@ def main(base_uri: str):
 
         if TEST:
             df_city_reviews.filter("city = 'Amsterdam'").write.partitionBy("year", "month", "city").parquet(
-                path_out_city_reviews_data
+                paths.path_out_city_reviews_data
             )
         else:
-            df_city_reviews.write.partitionBy("year", "month", "city").parquet(path_out_city_reviews_data)
+            df_city_reviews.write.partitionBy("year", "month", "city").parquet(paths.path_out_city_reviews_data)
 
-    if not model_exists(path_out_city_temperature_data):
+    if not model_exists(paths.path_out_city_temperature_data):
         text = (
-            sc.textFile(raw_city_temperature_path)
+            sc.textFile(paths.raw_city_temperature)
             .map(lambda line: line.replace(" ", "").split(","))
             .filter(lambda line: len(line) == 5)
             .filter(lambda line: line[0] != "STAID")
@@ -184,11 +133,11 @@ def main(base_uri: str):
         df = spark.createDataFrame(text)
         columns = ["STAID", "SOUID", "DATE", "TG", "Q_TG"]
         df = df.toDF(*columns)
-        df.write.parquet(path_out_city_temperature_data)
+        df.write.parquet(paths.path_out_city_temperature_data)
 
-    if not model_exists(path_out_city_rain_data):
+    if not model_exists(paths.path_out_city_rain_data):
         text = (
-            sc.textFile(raw_city_rain_data_path)
+            sc.textFile(paths.raw_city_rain)
             .map(lambda line: line.replace(" ", "").split(","))
             .filter(lambda line: len(line) == 5)
             .filter(lambda line: line[0] != "STAID")
@@ -197,13 +146,13 @@ def main(base_uri: str):
         df = spark.createDataFrame(text)
         columns = ["STAID", "SOUID", "DATE", "RR", "Q_TG"]
         df = df.toDF(*columns)
-        df.write.parquet(path_out_city_rain_data)
+        df.write.parquet(paths.path_out_city_rain_data)
 
-    if not model_exists(path_out_weather_stations):
+    if not model_exists(paths.path_out_weather_stations):
         station_city = [(593, "Amsterdam"), (41, "Berlin"), (1860, "London"), (11249, "Paris")]
         columns = ["STAID", "city"]
         df_stations = spark.createDataFrame(data=station_city, schema=columns)
-        df_stations.write.parquet(path_out_weather_stations)
+        df_stations.write.parquet(paths.path_out_weather_stations)
 
 
 if __name__ == "__main__":

--- a/apps/process_listings_hosts.py
+++ b/apps/process_listings_hosts.py
@@ -5,9 +5,10 @@ import sys
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.window import Window
-from apps.utils import join_path, model_exists
 
-BUCKET_NAME = "airbnbprj-us"
+from apps.utils import DEFAULT_BUCKET_NAME, build_paths, model_exists
+
+BUCKET_NAME = DEFAULT_BUCKET_NAME
 
 
 def drop_host_columns(df: DataFrame) -> DataFrame:
@@ -42,63 +43,11 @@ def main(base_uri: str):
     ## Paths
     TEST = False
 
-    # S3
-    path_global_listings = "airbnb-listings.csv"
-    path_city_listings = f"cities/*/{scrape_year_month}/listings.csv"
-    path_city_reviews = f"cities/*/{scrape_year_month}/reviews.csv"
+    paths = build_paths(base_uri, scrape_year_month, TEST)
 
-    path_city_temperature = "weather/ECA_blend_tg/*.txt"
-    path_city_rain = "weather/ECA_blend_rr/*.txt"
-
-    raw_data_folder = "raw"
-    # input_parquet_folder = "input_parquets_notebook"
-    # dim_model_folder = "dim_model_notebook"
-    # dim_model_folder_new = "dim_model_notebook_temp"
-    input_parquet_folder = "input_parquets_airflow"
-    dim_model_folder = "dim_model_airflow"
-    dim_model_folder_new = "dim_model_airflow_temp"
-
-    if TEST:
-        input_parquet_folder += "_test"
-        dim_model_folder += "_test"
-        dim_model_folder_new += "_test"
-
-    raw_global_listings_path = join_path(base_uri, raw_data_folder, path_global_listings)
-    raw_city_listings_path = join_path(base_uri, raw_data_folder, path_city_listings)
-    raw_city_reviews_path = join_path(base_uri, raw_data_folder, path_city_reviews)
-    raw_city_temperature_path = join_path(base_uri, raw_data_folder, path_city_temperature)
-    raw_city_rain_data_path = join_path(base_uri, raw_data_folder, path_city_rain)
-
-    path_out_global_listings = join_path(base_uri, input_parquet_folder, "global_listings.parquet")
-    path_out_city_listings_data = join_path(
-        base_uri, input_parquet_folder, f"city_listings/{scrape_year_month}/city_listings.parquet"
-    )
-    path_out_city_reviews_data = join_path(
-        base_uri, input_parquet_folder, f"city_reviews/{scrape_year_month}/city_reviews.parquet"
-    )
-    path_out_city_temperature_data = join_path(base_uri, input_parquet_folder, "city_temperature.parquet")
-    path_out_city_rain_data = join_path(base_uri, input_parquet_folder, "city_rain.parquet")
-    path_out_weather_stations = join_path(base_uri, input_parquet_folder, "weather_stations.parquet")
-
-    dim_model_listings = join_path(base_uri, dim_model_folder, "listings.csv")
-    dim_model_hosts = join_path(base_uri, dim_model_folder, "hosts.csv")
-    dim_model_reviews = join_path(base_uri, dim_model_folder, "reviews.csv")
-    dim_model_reviewers = join_path(base_uri, dim_model_folder, "reviewers.csv")
-    dim_model_weather = join_path(base_uri, dim_model_folder, "weather.csv")
-
-    dim_model_listings_new = join_path(base_uri, dim_model_folder_new, "listings.csv")
-    dim_model_hosts_new = join_path(base_uri, dim_model_folder_new, "hosts.csv")
-    dim_model_reviews_new = join_path(base_uri, dim_model_folder_new, "reviews.csv")
-    dim_model_reviewers_new = join_path(base_uri, dim_model_folder_new, "reviewers.csv")
-    dim_model_weather_new = join_path(base_uri, dim_model_folder_new, "weather.csv")
-
-    dim_model_reviews_step1 = join_path(base_uri, dim_model_folder_new, "reviews_step1.csv")
-    dim_model_reviews_step2 = join_path(base_uri, dim_model_folder_new, "reviews_step2.csv")
-    ##
-
-    if not model_exists(dim_model_listings):
+    if not model_exists(paths.dim_model_listings):
         # import global listings
-        df_listings_global = spark.read.parquet(path_out_global_listings)
+        df_listings_global = spark.read.parquet(paths.path_out_global_listings)
         df_listings_global.createOrReplaceTempView("global")
         query = """
         SELECT *, cast(null as string) as bathrooms_text, cast(null as integer) as calculated_host_listings_count_entire_homes, cast(null as integer) as calculated_host_listings_count_private_rooms,
@@ -111,13 +60,13 @@ def main(base_uri: str):
         df_listings_hosts = df_listings_hosts.select(sorted(df_listings_hosts.columns))
         df_listings_hosts = df_listings_hosts.withColumnRenamed("id", "listing_id")
 
-    if not model_exists(dim_model_listings):
+    if not model_exists(paths.dim_model_listings):
         # drop hosts columns from listings, except host_id
         df_listings = drop_host_columns(df_listings_hosts)
 
-    if model_exists(dim_model_listings):
+    if model_exists(paths.dim_model_listings):
         df_listings = spark.read.csv(
-            dim_model_listings,
+            paths.dim_model_listings,
             header="True",
             inferSchema="True",
             multiLine="True",
@@ -125,7 +74,7 @@ def main(base_uri: str):
             ignoreLeadingWhiteSpace="True",
         )
 
-    df_listings_hosts_monthly = spark.read.parquet(path_out_city_listings_data)
+    df_listings_hosts_monthly = spark.read.parquet(paths.path_out_city_listings_data)
     df_listings_hosts_monthly = df_listings_hosts_monthly.select(sorted(df_listings_hosts_monthly.columns))
 
     # drop hosts columns from listings, except host_id
@@ -145,9 +94,9 @@ def main(base_uri: str):
         .drop("latest")
     )
 
-    df_listings_updated.write.csv(dim_model_listings_new, escape='"', header="true")
+    df_listings_updated.write.csv(paths.dim_model_listings_new, escape='"', header="true")
 
-    if not model_exists(dim_model_listings):
+    if not model_exists(paths.dim_model_listings):
         # create hosts table
         df_listings_hosts.createOrReplaceTempView("listings")
         query = """
@@ -158,7 +107,7 @@ def main(base_uri: str):
         """
         df_hosts = spark.sql(query)
 
-    if not model_exists(dim_model_listings):
+    if not model_exists(paths.dim_model_listings):
         windowSpec = (
             Window.partitionBy("host_id")
             .orderBy("last_scraped")
@@ -171,9 +120,9 @@ def main(base_uri: str):
             .drop("latest")
         )
 
-    if model_exists(dim_model_listings):
+    if model_exists(paths.dim_model_listings):
         df_hosts = spark.read.csv(
-            dim_model_hosts,
+            paths.dim_model_hosts,
             header="True",
             inferSchema="True",
             multiLine="True",
@@ -204,7 +153,7 @@ def main(base_uri: str):
         .drop("latest")
     )
 
-    df_hosts_updated.write.csv(dim_model_hosts_new, escape='"', header="true")
+    df_hosts_updated.write.csv(paths.dim_model_hosts_new, escape='"', header="true")
 
 
 if __name__ == "__main__":

--- a/apps/process_reviewers.py
+++ b/apps/process_reviewers.py
@@ -5,9 +5,10 @@ import sys
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.window import Window
-from apps.utils import join_path
 
-BUCKET_NAME = "airbnbprj-us"
+from apps.utils import DEFAULT_BUCKET_NAME, build_paths
+
+BUCKET_NAME = DEFAULT_BUCKET_NAME
 
 
 def build_reviewers_table(df_reviews: DataFrame) -> DataFrame:
@@ -36,62 +37,10 @@ def main(base_uri: str):
     ## Paths
     TEST = False
 
-    # S3
-    path_global_listings = "airbnb-listings.csv"
-    path_city_listings = f"cities/*/{scrape_year_month}/listings.csv"
-    path_city_reviews = f"cities/*/{scrape_year_month}/reviews.csv"
-
-    path_city_temperature = "weather/ECA_blend_tg/*.txt"
-    path_city_rain = "weather/ECA_blend_rr/*.txt"
-
-    raw_data_folder = "raw"
-    # input_parquet_folder = "input_parquets_notebook"
-    # dim_model_folder = "dim_model_notebook"
-    # dim_model_folder_new = "dim_model_notebook_temp"
-    input_parquet_folder = "input_parquets_airflow"
-    dim_model_folder = "dim_model_airflow"
-    dim_model_folder_new = "dim_model_airflow_temp"
-
-    if TEST:
-        input_parquet_folder += "_test"
-        dim_model_folder += "_test"
-        dim_model_folder_new += "_test"
-
-    raw_global_listings_path = join_path(base_uri, raw_data_folder, path_global_listings)
-    raw_city_listings_path = join_path(base_uri, raw_data_folder, path_city_listings)
-    raw_city_reviews_path = join_path(base_uri, raw_data_folder, path_city_reviews)
-    raw_city_temperature_path = join_path(base_uri, raw_data_folder, path_city_temperature)
-    raw_city_rain_data_path = join_path(base_uri, raw_data_folder, path_city_rain)
-
-    path_out_global_listings = join_path(base_uri, input_parquet_folder, "global_listings.parquet")
-    path_out_city_listings_data = join_path(
-        base_uri, input_parquet_folder, f"city_listings/{scrape_year_month}/city_listings.parquet"
-    )
-    path_out_city_reviews_data = join_path(
-        base_uri, input_parquet_folder, f"city_reviews/{scrape_year_month}/city_reviews.parquet"
-    )
-    path_out_city_temperature_data = join_path(base_uri, input_parquet_folder, "city_temperature.parquet")
-    path_out_city_rain_data = join_path(base_uri, input_parquet_folder, "city_rain.parquet")
-    path_out_weather_stations = join_path(base_uri, input_parquet_folder, "weather_stations.parquet")
-
-    dim_model_listings = join_path(base_uri, dim_model_folder, "listings.csv")
-    dim_model_hosts = join_path(base_uri, dim_model_folder, "hosts.csv")
-    dim_model_reviews = join_path(base_uri, dim_model_folder, "reviews.csv")
-    dim_model_reviewers = join_path(base_uri, dim_model_folder, "reviewers.csv")
-    dim_model_weather = join_path(base_uri, dim_model_folder, "weather.csv")
-
-    dim_model_listings_new = join_path(base_uri, dim_model_folder_new, "listings.csv")
-    dim_model_hosts_new = join_path(base_uri, dim_model_folder_new, "hosts.csv")
-    dim_model_reviews_new = join_path(base_uri, dim_model_folder_new, "reviews.csv")
-    dim_model_reviewers_new = join_path(base_uri, dim_model_folder_new, "reviewers.csv")
-    dim_model_weather_new = join_path(base_uri, dim_model_folder_new, "weather.csv")
-
-    dim_model_reviews_step1 = join_path(base_uri, dim_model_folder_new, "reviews_step1.csv")
-    dim_model_reviews_step2 = join_path(base_uri, dim_model_folder_new, "reviews_step2.csv")
-    ##
+    paths = build_paths(base_uri, scrape_year_month, TEST)
 
     df_reviews = spark.read.csv(
-        dim_model_reviews_new,
+        paths.dim_model_reviews_new,
         header="True",
         inferSchema="True",
         multiLine="True",
@@ -101,7 +50,7 @@ def main(base_uri: str):
 
     df_reviewers = build_reviewers_table(df_reviews)
 
-    df_reviewers.write.csv(dim_model_reviewers_new, escape='"', header="true")
+    df_reviewers.write.csv(paths.dim_model_reviewers_new, escape='"', header="true")
 
 
 if __name__ == "__main__":

--- a/apps/process_reviews.py
+++ b/apps/process_reviews.py
@@ -5,9 +5,10 @@ import sys
 
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame, SparkSession
-from apps.utils import join_path, model_exists
 
-BUCKET_NAME = "airbnbprj-us"
+from apps.utils import DEFAULT_BUCKET_NAME, build_paths, model_exists
+
+BUCKET_NAME = DEFAULT_BUCKET_NAME
 
 
 class DummyPretrainedPipeline:
@@ -74,64 +75,12 @@ def main(base_uri: str, use_dummy_pipeline: bool = False):
     ## Paths
     TEST = False
 
-    # S3
-    path_global_listings = "airbnb-listings.csv"
-    path_city_listings = f"cities/*/{scrape_year_month}/listings.csv"
-    path_city_reviews = f"cities/*/{scrape_year_month}/reviews.csv"
+    paths = build_paths(base_uri, scrape_year_month, TEST)
 
-    path_city_temperature = "weather/ECA_blend_tg/*.txt"
-    path_city_rain = "weather/ECA_blend_rr/*.txt"
-
-    raw_data_folder = "raw"
-    # input_parquet_folder = "input_parquets_notebook"
-    # dim_model_folder = "dim_model_notebook"
-    # dim_model_folder_new = "dim_model_notebook_temp"
-    input_parquet_folder = "input_parquets_airflow"
-    dim_model_folder = "dim_model_airflow"
-    dim_model_folder_new = "dim_model_airflow_temp"
-
-    if TEST:
-        input_parquet_folder += "_test"
-        dim_model_folder += "_test"
-        dim_model_folder_new += "_test"
-
-    raw_global_listings_path = join_path(base_uri, raw_data_folder, path_global_listings)
-    raw_city_listings_path = join_path(base_uri, raw_data_folder, path_city_listings)
-    raw_city_reviews_path = join_path(base_uri, raw_data_folder, path_city_reviews)
-    raw_city_temperature_path = join_path(base_uri, raw_data_folder, path_city_temperature)
-    raw_city_rain_data_path = join_path(base_uri, raw_data_folder, path_city_rain)
-
-    path_out_global_listings = join_path(base_uri, input_parquet_folder, "global_listings.parquet")
-    path_out_city_listings_data = join_path(
-        base_uri, input_parquet_folder, f"city_listings/{scrape_year_month}/city_listings.parquet"
-    )
-    path_out_city_reviews_data = join_path(
-        base_uri, input_parquet_folder, f"city_reviews/{scrape_year_month}/city_reviews.parquet"
-    )
-    path_out_city_temperature_data = join_path(base_uri, input_parquet_folder, "city_temperature.parquet")
-    path_out_city_rain_data = join_path(base_uri, input_parquet_folder, "city_rain.parquet")
-    path_out_weather_stations = join_path(base_uri, input_parquet_folder, "weather_stations.parquet")
-
-    dim_model_listings = join_path(base_uri, dim_model_folder, "listings.csv")
-    dim_model_hosts = join_path(base_uri, dim_model_folder, "hosts.csv")
-    dim_model_reviews = join_path(base_uri, dim_model_folder, "reviews.csv")
-    dim_model_reviewers = join_path(base_uri, dim_model_folder, "reviewers.csv")
-    dim_model_weather = join_path(base_uri, dim_model_folder, "weather.csv")
-
-    dim_model_listings_new = join_path(base_uri, dim_model_folder_new, "listings.csv")
-    dim_model_hosts_new = join_path(base_uri, dim_model_folder_new, "hosts.csv")
-    dim_model_reviews_new = join_path(base_uri, dim_model_folder_new, "reviews.csv")
-    dim_model_reviewers_new = join_path(base_uri, dim_model_folder_new, "reviewers.csv")
-    dim_model_weather_new = join_path(base_uri, dim_model_folder_new, "weather.csv")
-
-    dim_model_reviews_step1 = join_path(base_uri, dim_model_folder_new, "reviews_step1.csv")
-    dim_model_reviews_step2 = join_path(base_uri, dim_model_folder_new, "reviews_step2.csv")
-    ##
-
-    df_reviews_monthly = spark.read.parquet(path_out_city_reviews_data)
+    df_reviews_monthly = spark.read.parquet(paths.path_out_city_reviews_data)
 
     df_listings = spark.read.csv(
-        dim_model_listings_new,
+        paths.dim_model_listings_new,
         header="True",
         inferSchema="True",
         multiLine="True",
@@ -139,12 +88,12 @@ def main(base_uri: str, use_dummy_pipeline: bool = False):
         ignoreLeadingWhiteSpace="True",
     )
 
-    if not model_exists(dim_model_reviews):
+    if not model_exists(paths.dim_model_reviews):
         df_reviews_delta = df_reviews_monthly
 
     else:
         df_reviews = spark.read.csv(
-            dim_model_reviews,
+            paths.dim_model_reviews,
             header="True",
             inferSchema="True",
             multiLine="True",
@@ -174,7 +123,7 @@ def main(base_uri: str, use_dummy_pipeline: bool = False):
     """
     df_reviews_delta = spark.sql(query)
 
-    df_reviews_delta.write.csv(dim_model_reviews_step1, escape='"', header="true")
+    df_reviews_delta.write.csv(paths.dim_model_reviews_step1, escape='"', header="true")
 
     if TEST:
         df_reviews_delta = df_reviews_delta.limit(10000)
@@ -190,10 +139,10 @@ def main(base_uri: str, use_dummy_pipeline: bool = False):
         .withColumnRenamed("text", "comments")
     )
 
-    df_reviews_delta2.write.csv(dim_model_reviews_step2, escape='"', header="true")
+    df_reviews_delta2.write.csv(paths.dim_model_reviews_step2, escape='"', header="true")
 
     df_reviews_delta2 = spark.read.csv(
-        dim_model_reviews_step2,
+        paths.dim_model_reviews_step2,
         header="True",
         inferSchema="True",
         multiLine="True",
@@ -204,11 +153,11 @@ def main(base_uri: str, use_dummy_pipeline: bool = False):
     sentiment_analyzer = get_pipeline("analyze_sentimentdl_use_imdb", lang="en", use_dummy=use_dummy_pipeline)
     df_reviews_delta3 = apply_language_and_sentiment(df_reviews_delta2, language_detector, sentiment_analyzer)
 
-    if not model_exists(dim_model_reviews):
-        df_reviews_delta3.write.csv(dim_model_reviews_new, escape='"', header="true")
+    if not model_exists(paths.dim_model_reviews):
+        df_reviews_delta3.write.csv(paths.dim_model_reviews_new, escape='"', header="true")
     else:
         df_reviews = spark.read.csv(
-            dim_model_reviews,
+            paths.dim_model_reviews,
             header="True",
             inferSchema="True",
             multiLine="True",
@@ -218,7 +167,7 @@ def main(base_uri: str, use_dummy_pipeline: bool = False):
         df_reviews_updated = df_reviews.union(df_reviews_delta3)
         # Its necessary to drop duplicates since some of the reviews submitted at the scrape date will be included twice
         df_reviews_updated = df_reviews_updated.dropDuplicates(["review_id"])
-        df_reviews_updated.write.csv(dim_model_reviews_new, escape='"', header="true")
+        df_reviews_updated.write.csv(paths.dim_model_reviews_new, escape='"', header="true")
 
 
 if __name__ == "__main__":

--- a/apps/process_weather.py
+++ b/apps/process_weather.py
@@ -4,9 +4,10 @@ import sys
 
 import pyspark.sql.functions as F
 from pyspark.sql import DataFrame, SparkSession
-from apps.utils import join_path
 
-BUCKET_NAME = "airbnbprj-us"
+from apps.utils import DEFAULT_BUCKET_NAME, build_paths
+
+BUCKET_NAME = DEFAULT_BUCKET_NAME
 
 
 def join_weather(df_temp: DataFrame, df_rain: DataFrame, df_stations: DataFrame) -> DataFrame:
@@ -32,67 +33,15 @@ def main(base_uri: str):
     ## Paths
     TEST = False
 
-    # S3
-    path_global_listings = "airbnb-listings.csv"
-    path_city_listings = f"cities/*/{scrape_year_month}/listings.csv"
-    path_city_reviews = f"cities/*/{scrape_year_month}/reviews.csv"
+    paths = build_paths(base_uri, scrape_year_month, TEST)
 
-    path_city_temperature = "weather/ECA_blend_tg/*.txt"
-    path_city_rain = "weather/ECA_blend_rr/*.txt"
-
-    raw_data_folder = "raw"
-    # input_parquet_folder = "input_parquets_notebook"
-    # dim_model_folder = "dim_model_notebook"
-    # dim_model_folder_new = "dim_model_notebook_temp"
-    input_parquet_folder = "input_parquets_airflow"
-    dim_model_folder = "dim_model_airflow"
-    dim_model_folder_new = "dim_model_airflow_temp"
-
-    if TEST:
-        input_parquet_folder += "_test"
-        dim_model_folder += "_test"
-        dim_model_folder_new += "_test"
-
-    raw_global_listings_path = join_path(base_uri, raw_data_folder, path_global_listings)
-    raw_city_listings_path = join_path(base_uri, raw_data_folder, path_city_listings)
-    raw_city_reviews_path = join_path(base_uri, raw_data_folder, path_city_reviews)
-    raw_city_temperature_path = join_path(base_uri, raw_data_folder, path_city_temperature)
-    raw_city_rain_data_path = join_path(base_uri, raw_data_folder, path_city_rain)
-
-    path_out_global_listings = join_path(base_uri, input_parquet_folder, "global_listings.parquet")
-    path_out_city_listings_data = join_path(
-        base_uri, input_parquet_folder, f"city_listings/{scrape_year_month}/city_listings.parquet"
-    )
-    path_out_city_reviews_data = join_path(
-        base_uri, input_parquet_folder, f"city_reviews/{scrape_year_month}/city_reviews.parquet"
-    )
-    path_out_city_temperature_data = join_path(base_uri, input_parquet_folder, "city_temperature.parquet")
-    path_out_city_rain_data = join_path(base_uri, input_parquet_folder, "city_rain.parquet")
-    path_out_weather_stations = join_path(base_uri, input_parquet_folder, "weather_stations.parquet")
-
-    dim_model_listings = join_path(base_uri, dim_model_folder, "listings.csv")
-    dim_model_hosts = join_path(base_uri, dim_model_folder, "hosts.csv")
-    dim_model_reviews = join_path(base_uri, dim_model_folder, "reviews.csv")
-    dim_model_reviewers = join_path(base_uri, dim_model_folder, "reviewers.csv")
-    dim_model_weather = join_path(base_uri, dim_model_folder, "weather.csv")
-
-    dim_model_listings_new = join_path(base_uri, dim_model_folder_new, "listings.csv")
-    dim_model_hosts_new = join_path(base_uri, dim_model_folder_new, "hosts.csv")
-    dim_model_reviews_new = join_path(base_uri, dim_model_folder_new, "reviews.csv")
-    dim_model_reviewers_new = join_path(base_uri, dim_model_folder_new, "reviewers.csv")
-    dim_model_weather_new = join_path(base_uri, dim_model_folder_new, "weather.csv")
-
-    dim_model_reviews_step1 = join_path(base_uri, dim_model_folder_new, "reviews_step1.csv")
-    dim_model_reviews_step2 = join_path(base_uri, dim_model_folder_new, "reviews_step2.csv")
-    ##
-
-    df_temp = spark.read.parquet(path_out_city_temperature_data)
-    df_rain = spark.read.parquet(path_out_city_rain_data)
-    df_stations = spark.read.parquet(path_out_weather_stations)
+    df_temp = spark.read.parquet(paths.path_out_city_temperature_data)
+    df_rain = spark.read.parquet(paths.path_out_city_rain_data)
+    df_stations = spark.read.parquet(paths.path_out_weather_stations)
 
     df_weather = join_weather(df_temp, df_rain, df_stations)
 
-    df_weather.write.csv(dim_model_weather_new, escape='"', header="true")
+    df_weather.write.csv(paths.dim_model_weather_new, escape='"', header="true")
 
 
 if __name__ == "__main__":

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -1,6 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 from pathlib import Path
 
 import boto3
+
+DEFAULT_BUCKET_NAME = "airbnbprj-us"
+
+
+@dataclass(frozen=True)
+class DataPaths:
+    raw_global_listings: str
+    raw_city_listings: str
+    raw_city_reviews: str
+    raw_city_temperature: str
+    raw_city_rain: str
+    path_out_global_listings: str
+    path_out_city_listings_data: str
+    path_out_city_reviews_data: str
+    path_out_city_temperature_data: str
+    path_out_city_rain_data: str
+    path_out_weather_stations: str
+    dim_model_listings: str
+    dim_model_hosts: str
+    dim_model_reviews: str
+    dim_model_reviewers: str
+    dim_model_weather: str
+    dim_model_listings_new: str
+    dim_model_hosts_new: str
+    dim_model_reviews_new: str
+    dim_model_reviewers_new: str
+    dim_model_weather_new: str
+    dim_model_reviews_step1: str
+    dim_model_reviews_step2: str
 
 
 def join_path(base: str, *parts: str) -> str:
@@ -18,3 +50,56 @@ def model_exists(path: str) -> bool:
         response = s3_client.list_objects(Bucket=bucket, MaxKeys=1, Prefix=key)
         return "Contents" in response
     return Path(path).exists()
+
+
+def build_paths(base_uri: str, scrape_year_month: str, test: bool = False) -> DataPaths:
+    """Return all data paths used in the ETL pipeline."""
+    raw_data_folder = "raw"
+    input_parquet_folder = "input_parquets_airflow"
+    dim_model_folder = "dim_model_airflow"
+    dim_model_folder_new = "dim_model_airflow_temp"
+
+    if test:
+        input_parquet_folder += "_test"
+        dim_model_folder += "_test"
+        dim_model_folder_new += "_test"
+
+    path_global_listings = "airbnb-listings.csv"
+    path_city_listings = f"cities/*/{scrape_year_month}/listings.csv"
+    path_city_reviews = f"cities/*/{scrape_year_month}/reviews.csv"
+    path_city_temperature = "weather/ECA_blend_tg/*.txt"
+    path_city_rain = "weather/ECA_blend_rr/*.txt"
+
+    return DataPaths(
+        raw_global_listings=join_path(base_uri, raw_data_folder, path_global_listings),
+        raw_city_listings=join_path(base_uri, raw_data_folder, path_city_listings),
+        raw_city_reviews=join_path(base_uri, raw_data_folder, path_city_reviews),
+        raw_city_temperature=join_path(base_uri, raw_data_folder, path_city_temperature),
+        raw_city_rain=join_path(base_uri, raw_data_folder, path_city_rain),
+        path_out_global_listings=join_path(base_uri, input_parquet_folder, "global_listings.parquet"),
+        path_out_city_listings_data=join_path(
+            base_uri,
+            input_parquet_folder,
+            f"city_listings/{scrape_year_month}/city_listings.parquet",
+        ),
+        path_out_city_reviews_data=join_path(
+            base_uri,
+            input_parquet_folder,
+            f"city_reviews/{scrape_year_month}/city_reviews.parquet",
+        ),
+        path_out_city_temperature_data=join_path(base_uri, input_parquet_folder, "city_temperature.parquet"),
+        path_out_city_rain_data=join_path(base_uri, input_parquet_folder, "city_rain.parquet"),
+        path_out_weather_stations=join_path(base_uri, input_parquet_folder, "weather_stations.parquet"),
+        dim_model_listings=join_path(base_uri, dim_model_folder, "listings.csv"),
+        dim_model_hosts=join_path(base_uri, dim_model_folder, "hosts.csv"),
+        dim_model_reviews=join_path(base_uri, dim_model_folder, "reviews.csv"),
+        dim_model_reviewers=join_path(base_uri, dim_model_folder, "reviewers.csv"),
+        dim_model_weather=join_path(base_uri, dim_model_folder, "weather.csv"),
+        dim_model_listings_new=join_path(base_uri, dim_model_folder_new, "listings.csv"),
+        dim_model_hosts_new=join_path(base_uri, dim_model_folder_new, "hosts.csv"),
+        dim_model_reviews_new=join_path(base_uri, dim_model_folder_new, "reviews.csv"),
+        dim_model_reviewers_new=join_path(base_uri, dim_model_folder_new, "reviewers.csv"),
+        dim_model_weather_new=join_path(base_uri, dim_model_folder_new, "weather.csv"),
+        dim_model_reviews_step1=join_path(base_uri, dim_model_folder_new, "reviews_step1.csv"),
+        dim_model_reviews_step2=join_path(base_uri, dim_model_folder_new, "reviews_step2.csv"),
+    )


### PR DESCRIPTION
## Summary
- add `DataPaths` and `build_paths` helpers in `apps.utils`
- update ETL scripts to use the common path builder

## Testing
- `ruff check apps/preprocess_data.py apps/process_listings_hosts.py apps/process_reviews.py apps/process_reviewers.py apps/process_weather.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582398ee70832487faad07629a0488